### PR TITLE
Update File.cs Bug Fix

### DIFF
--- a/src/File.cs
+++ b/src/File.cs
@@ -83,7 +83,8 @@ namespace FroalaEditor
 
             // Generate Random name.
             string extension = Utils.GetFileExtension(file.FileName);
-            string name = Utils.GenerateUniqueString() + "." + extension;
+            // Fixed Bug 1 : bug caused by uppercase file extension
+            string name = Utils.GenerateUniqueString() + "." + extension.ToLower(CultureInfo.InvariantCulture);
 
             string link = fileRoute + name; 
 
@@ -110,7 +111,8 @@ namespace FroalaEditor
             if (options.Validation != null && !options.Validation.Check(serverPath, file.ContentType))
             {
                 // Delete file.
-                Delete(serverPath);
+                // Fixed Bug 2 : wrong parameter sending, it must be "link", not "serverPath"
+                Delete(link);
                 throw new Exception("File does not meet the validation.");
             }
 


### PR DESCRIPTION
Bug 1:
If the file extension consists of uppercase letters, when the allowed file types are checked, it causes to  throw an error.
To fix this, the file extension has been changed to lowercase. Now, the file will save with this extension.

Bug 2:
When the validation conditions are not met, the delete method that run inside brackets, had taken wrong parameter. The parameter must be relative path but it's not. Because of that it has changed with right parameter which that is the variable named link.

P.S.: I didn't check for netcore but probably it will work well.