### PR TITLE
Update Upload method in File.cs

### DIFF
--- a/src/File.cs
+++ b/src/File.cs
@@ -83,7 +83,8 @@ namespace FroalaEditor
 
             // Generate Random name.
             string extension = Utils.GetFileExtension(file.FileName);
-            string name = Utils.GenerateUniqueString() + "." + extension;
+            // Fixed Bug 1 : bug caused by uppercase file extension
+            string name = Utils.GenerateUniqueString() + "." + extension.ToLower(CultureInfo.InvariantCulture);
 
             string link = fileRoute + name; 
 
@@ -110,7 +111,8 @@ namespace FroalaEditor
             if (options.Validation != null && !options.Validation.Check(serverPath, file.ContentType))
             {
                 // Delete file.
-                Delete(serverPath);
+                // Fixed Bug 2 : wrong parameter sending, it must be "link", not "serverPath"
+                Delete(link);
                 throw new Exception("File does not meet the validation.");
             }
 

--- a/src/File.cs
+++ b/src/File.cs
@@ -89,7 +89,7 @@ namespace FroalaEditor
             string link = fileRoute + name; 
 
             // Create directory if it doesn't exist.
-            FileInfo dir = new FileInfo(fileRoute);
+            FileInfo dir = new FileInfo(File.GetAbsoluteServerPath(fileRoute));
             dir.Directory.Create();
 
             // Copy contents to memory stream.


### PR DESCRIPTION
Last update is about creating folder in wrong location.

FileInfo dir = new FileInfo(File.GetAbsoluteServerPath(fileRoute));
This row causes creating a folder in C drive. fileRoute parameter has to be absolute path but it is relative here. So, it must be File.GetAbsoluteServerPath(fileRoute) statement instead of fileRoute parameter.