### PR TITLE
2567: .Net SDK: File upload is not working for files other than pdf (e.g. *.jpg, *.png, *.mp4)

### DIFF
--- a/src/File/FileValidation.cs
+++ b/src/File/FileValidation.cs
@@ -11,12 +11,12 @@ namespace FroalaEditor
         /// <summary>
         /// Allowed file validation default extensions.
         /// </summary>
-        public static string[] AllowedFileExtsDefault = new string[] { "txt", "pdf", "doc" };
+        public static string[] AllowedFileExtsDefault = new string[] { "txt", "pdf", "doc" , "png", "jpg" , "mp4"};
 
         /// <summary>
         /// Allowed file validation default mimetypes.
         /// </summary>
-        public static string[] AllowedFileMimetypesDefault = new string[] { "text/plain", "application/msword", "application/x-pdf", "application/pdf" };
+        public static string[] AllowedFileMimetypesDefault = new string[] { "text/plain", "application/msword", "application/x-pdf", "application/pdf", "image/png" , "video/mp4", "image/jpeg" };
 
         /// <summary>
         /// Allowed validation extensions.


### PR DESCRIPTION

Issue: https://github.com/froala-labs/froala-editor-js-2/issues/2567
Description: .Net SDK: File upload is not working for files other than pdf (e.g. *.jpg, *.png, *.mp4)
fix: added support for file formats : ( *.jpg, *.png, *.mp4)